### PR TITLE
Update Minecraft Wiki links to new domain

### DIFF
--- a/lib/utils/Minecraft.ts
+++ b/lib/utils/Minecraft.ts
@@ -29,7 +29,7 @@ export enum FormattingCodes {
 	Reset = '§r'
 }
 
-// https://minecraft.fandom.com/wiki/Formatting_codes
+// https://minecraft.wiki/w/Formatting_codes
 export const formattingInfo = {
 	[FormattingCodes.Black]: {
 		foreground: 'rgb(0, 0, 0)',


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates the Fandom wiki link accordingly.